### PR TITLE
Corrected some smaller syntax errors

### DIFF
--- a/_chapters/chapters/apm.md
+++ b/_chapters/chapters/apm.md
@@ -200,7 +200,7 @@ This is your first user story: *"As a developer, I want to settle the Definition
   - Encoding
 - Helpful for *Collective Code Ownership* within small teams, indispensable for open source
   - E.g. Google's Java style guide
-  - [https://google-styleguide.googlecode.com/svn/trunk/javaguide.html]
+  - <https://google-styleguide.googlecode.com/svn/trunk/javaguide.html>
 
 ### Code Review
 

--- a/_chapters/chapters/dialogueunderstanding.md
+++ b/_chapters/chapters/dialogueunderstanding.md
@@ -347,11 +347,11 @@ This tutorial introduces how to use IBM Watson SDK in Unity 3D in order to inter
 
 *Service endpoints by location:*
 
-·    London: <https://api.eu-gb.assistant.watson.cloud.ibm.com>
+·    *London:* <https://api.eu-gb.assistant.watson.cloud.ibm.com>
 
-·    Frankfurt: <https://api.eu-de.assistant.watson.cloud.ibm.com>
+·    *Frankfurt:* <https://api.eu-de.assistant.watson.cloud.ibm.com>
 
-·    Washington, DC: <https://api.us-east.assistant.watson.cloud.ibm.com>
+·    *Washington, DC:* <https://api.us-east.assistant.watson.cloud.ibm.com>
 
 <figure>
     <img src="{{pathToRoot}}/assets/figures/dialogue_understanding/Step%205.3.png" style="align:left; width: 60%; height: 60%; border: 15px solid;
@@ -418,11 +418,11 @@ This tutorial introduces how to use IBM Watson SDK in Unity 3D in order to inter
 
 *Service of Text to Speech endpoints by location*
 
-·    Washington DC: <https://api.us-east.text-to-speech.watson.cloud.ibm.com>
+·    *Washington DC*: <https://api.us-east.text-to-speech.watson.cloud.ibm.com>
 
-·    Frankfurt: <https://api.eu-de.text-to-speech.watson.cloud.ibm.com>
+·    *Frankfurt:* <https://api.eu-de.text-to-speech.watson.cloud.ibm.com>
 
-·    London: <https://api.eu-gb.text-to-speech.watson.cloud.ibm.com>
+·    *London:* <https://api.eu-gb.text-to-speech.watson.cloud.ibm.com>
 
 ​
 ​         

--- a/_chapters/chapters/dialogueunderstanding.md
+++ b/_chapters/chapters/dialogueunderstanding.md
@@ -25,7 +25,7 @@ visualizations:
 
 ### **Part 1. Creating an IBM Cloud account** {#part1}
 
-Step 1.1: Register an account https://cloud.ibm.com/login > create an IBM Cloud account > you’ll be asked to verify your email > complete personal information > login your account and accept the privacy notices. 
+Step 1.1: Register an account <https://cloud.ibm.com/login> > create an IBM Cloud account > you’ll be asked to verify your email > complete personal information > login your account and accept the privacy notices. 
 
 <figure>
     <img src="{{pathToRoot}}/assets/figures/dialogue_understanding/Step%201.1.png" style="align:left; width: 60%; height: 60%; border: 15px solid;
@@ -347,11 +347,11 @@ This tutorial introduces how to use IBM Watson SDK in Unity 3D in order to inter
 
 *Service endpoints by location:*
 
-·    London: https://api.eu-gb.assistant.watson.cloud.ibm.com
+·    London: <https://api.eu-gb.assistant.watson.cloud.ibm.com>
 
-·    Frankfurt: https://api.eu-de.assistant.watson.cloud.ibm.com
+·    Frankfurt: <https://api.eu-de.assistant.watson.cloud.ibm.com>
 
-·    Washington, DC: https://api.us-east.assistant.watson.cloud.ibm.com
+·    Washington, DC: <https://api.us-east.assistant.watson.cloud.ibm.com>
 
 <figure>
     <img src="{{pathToRoot}}/assets/figures/dialogue_understanding/Step%205.3.png" style="align:left; width: 60%; height: 60%; border: 15px solid;

--- a/_chapters/chapters/dialogueunderstanding.md
+++ b/_chapters/chapters/dialogueunderstanding.md
@@ -418,7 +418,7 @@ This tutorial introduces how to use IBM Watson SDK in Unity 3D in order to inter
 
 *Service of Text to Speech endpoints by location*
 
-·    *Washington DC*: <https://api.us-east.text-to-speech.watson.cloud.ibm.com>
+·    *Washington, DC*: <https://api.us-east.text-to-speech.watson.cloud.ibm.com>
 
 ·    *Frankfurt:* <https://api.eu-de.text-to-speech.watson.cloud.ibm.com>
 

--- a/_chapters/chapters/dialogueunderstanding.md
+++ b/_chapters/chapters/dialogueunderstanding.md
@@ -414,17 +414,17 @@ This tutorial introduces how to use IBM Watson SDK in Unity 3D in order to inter
 
 ·    *London:* [*https://api.eu-gb.speech-to-text.watson.cloud.ibm.com*](https://api.eu-gb.speech-to-text.watson.cloud.ibm.com)
 
-​         
-​         
-​         *Service of Text to Speech endpoints by location*
-​         
-​         ·    Washington DC: <https://api.us-east.text-to-speech.watson.cloud.ibm.com>
-​         
-​         ·    Frankfurt: <https://api.eu-de.text-to-speech.watson.cloud.ibm.com>
-​         
-​         ·    London: <https://api.eu-gb.text-to-speech.watson.cloud.ibm.com>
-​         
-​         
+
+
+*Service of Text to Speech endpoints by location*
+
+·    Washington DC: <https://api.us-east.text-to-speech.watson.cloud.ibm.com>
+
+·    Frankfurt: <https://api.eu-de.text-to-speech.watson.cloud.ibm.com>
+
+·    London: <https://api.eu-gb.text-to-speech.watson.cloud.ibm.com>
+
+​
 ​         
 ​         **Step 5.8.** Before playing it, we need to configure your service credentials. Save unity file (Ctrl+S), close Unity > open the location of the Unity file > find ibm_credentials.env, and open it.
 ​         

--- a/_chapters/chapters/dialogueunderstanding.md
+++ b/_chapters/chapters/dialogueunderstanding.md
@@ -406,7 +406,7 @@ This tutorial introduces how to use IBM Watson SDK in Unity 3D in order to inter
 
 
 
-Service of Speech to Text endpoints by location*
+*Service of Speech to Text endpoints by location*
 
 ·    *Washington, DC:* [*https://api.us-east.speech-to-text.watson.cloud.ibm.com*](https://api.us-east.speech-to-text.watson.cloud.ibm.com)
 

--- a/_chapters/chapters/dialogueunderstanding.md
+++ b/_chapters/chapters/dialogueunderstanding.md
@@ -418,11 +418,11 @@ This tutorial introduces how to use IBM Watson SDK in Unity 3D in order to inter
 ​         
 ​         *Service of Text to Speech endpoints by location*
 ​         
-​         ·    Washington DC: https://api.us-east.text-to-speech.watson.cloud.ibm.com
+​         ·    Washington DC: <https://api.us-east.text-to-speech.watson.cloud.ibm.com>
 ​         
-​         ·    Frankfurt: https://api.eu-de.text-to-speech.watson.cloud.ibm.com
+​         ·    Frankfurt: <https://api.eu-de.text-to-speech.watson.cloud.ibm.com>
 ​         
-​         ·    London: https://api.eu-gb.text-to-speech.watson.cloud.ibm.com
+​         ·    London: <https://api.eu-gb.text-to-speech.watson.cloud.ibm.com>
 ​         
 ​         
 ​         

--- a/_chapters/chapters/dialogueunderstanding.md
+++ b/_chapters/chapters/dialogueunderstanding.md
@@ -343,7 +343,7 @@ This tutorial introduces how to use IBM Watson SDK in Unity 3D in order to inter
 
 
 
-**Note:** However, if your URL is very long, it cannot work in Unity. For example, in this picture the URL should be https://api.eu-gb.assistant.watson.cloud.ibm.com
+**Note:** However, if your URL is very long, it cannot work in Unity. For example, in this picture the URL should be <https://api.eu-gb.assistant.watson.cloud.ibm.com>
 
 *Service endpoints by location:*
 

--- a/_chapters/chapters/mapgazegesture.md
+++ b/_chapters/chapters/mapgazegesture.md
@@ -512,5 +512,5 @@ Those routines simply remember the colour in use of the brain segment (they all 
     <figcaption>OnTapped</figcaption>
 </figure>
 
-NOTE: The 3D brain model is from https://free3d.com/3d-model/brain-18357.html and free for personal use.
+NOTE: The 3D brain model is from <https://free3d.com/3d-model/brain-18357.html> and free for personal use.
 The Placeable and GazeGestureManager behaviour scripts are from the Mi-crosoft Holoacademy Spatial Mapping tutorial.

--- a/_chapters/chapters/sharing.md
+++ b/_chapters/chapters/sharing.md
@@ -978,7 +978,7 @@ They are not covered in this tutorial since they require a lot more implementati
 - **Avatars**: The same way that we synchronized the playing stones, we can also synchronize the position and rotation of the head-mounted display.
   If we connect this information with some avatar representation, we can visualize remote users in the shared environment.
 
-### Testing on one PC
+### Testing on one PC {#Testing}
 
 Of course, collaborative applications can be tested on two PCs or devices by running the application on each device.
 However, the shared application can also be tested directly on one development PC.

--- a/_chapters/chapters/web.md
+++ b/_chapters/chapters/web.md
@@ -31,7 +31,7 @@ Moreover, Web browsers can communicate directly with each other without the need
 # WebXR
 
 WebXR (Mixed Reality on the Web) superseded WebVR in 2018.
-The [W3c editor's draft] (https://immersive-web.github.io/webxr/)
+The [W3c editor's draft](https://immersive-web.github.io/webxr/)
 gives details on the WebXR Device API.
 WebXR is an extension of the WebVR API covering augmented reality devices in the JavaScript API.
 The new API has two goals.


### PR DESCRIPTION
A few links and embedded links had the wrong formatting syntax (like for example [url] instead of \<url\>). Additionally, some urls were not formatted as links at all and at one place a reference tag was missing.